### PR TITLE
Export PersistOption type for consumption

### DIFF
--- a/src/configurePersist.ts
+++ b/src/configurePersist.ts
@@ -10,7 +10,7 @@ import {
 } from './keeper'
 import reconcile, { NonFunctionPropertyNames } from './reconcile'
 
-interface PersistOption<S extends State> {
+export interface PersistOption<S extends State> {
   key: string
   denylist?: NonFunctionPropertyNames<S>[]
   allowlist?: NonFunctionPropertyNames<S>[]


### PR DESCRIPTION
I found myself wanting to build wrappers so that stores can be built with base parameters and the types are needed to do that (or else we'd have to manually write our own types and that obviously is prone to error if things change).