### PR TITLE
Fix for PersistGate hanging on loading screen

### DIFF
--- a/src/LoadManager.ts
+++ b/src/LoadManager.ts
@@ -17,6 +17,16 @@ export class LoadManager {
 
   onAllLoaded(callback: () => void) {
     this.onAllLoadedCallback = callback
+
+    // Possible this could be called with a custom callback *after*
+    // loading has finished. Which means setLoaded (below) has finished
+    // being called and the custom callback would never be run.
+    // If loading has finished, execute callback immediately.
+    // https://github.com/roadmanfong/zustand-persist/issues/4
+    // https://github.com/roadmanfong/zustand-persist/issues/9
+    if (Object.values(this.loadStatusRecord).every(Boolean)) {
+      this.onAllLoadedCallback()
+    }
   }
 
   setLoaded(key: string) {

--- a/src/PersistGate.tsx
+++ b/src/PersistGate.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { getLoadManager } from './LoadManager'
 
 export interface PersistGateProps {
@@ -11,10 +11,15 @@ export function PersistGate(props: PersistGateProps) {
   const { children, loading = false, onBeforeLift } = props
   const [isReady, setIsReady] = useState(false)
 
-  getLoadManager().onAllLoaded(async () => {
-    onBeforeLift && (await onBeforeLift())
-    setIsReady(true)
-  })
+  // Only need to call this once on initial render.
+  // https://github.com/roadmanfong/zustand-persist/issues/4
+  // https://github.com/roadmanfong/zustand-persist/issues/9
+  useEffect(() => {
+    getLoadManager().onAllLoaded(async () => {
+      onBeforeLift && (await onBeforeLift())
+      setIsReady(true)
+    })
+  }, [])
 
   return <React.Fragment>{isReady ? children : loading}</React.Fragment>
 }


### PR DESCRIPTION
These changes should avoid the situation where PersistGate hangs. A race condition can occur when the data finished loading (in LoadManager) before the PersistGate has had a chance to render (and register it's custom callback with LoadManager). This means the callback is never called and the isReady state in PersistGate is never set to true. Should fix both #4 and #9.