### PR TITLE
Adding repo no longer maintained note to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+⚠️ This project is no longer being maintained ⚠️
+
+Zustand now has built in persistence middleware, so has persist functionality out of the box. Read more in the [Zustand readme](https://github.com/pmndrs/zustand#persist-middleware).
+
 # Zustand persist
 
 Persist and rehydrate state works on react and react native.


### PR DESCRIPTION
Adding note to readme that persistence now comes out of the box with zustand, and that this library is no longer maintained.